### PR TITLE
Addresses deprecation warnings in github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,8 @@ jobs:
           rustup target add wasm32-unknown-unknown
 
       - name: Install trunk
-        uses: jetli/trunk-action@68dbd78ba531c95d8ce3d262c9e63291926e9353 # v0.4.0
-        with:
-          version: 'latest'
+        run: |
+          cargo install --locked trunk
       - name: Build
         run: trunk build --release
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,19 +27,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
-          profile: minimal
+      - name: Install wasm target
+        run: |
+          rustup target add wasm32-unknown-unknown
 
       - name: Install trunk
-        uses: jetli/trunk-action@v0.1.0
+        uses: jetli/trunk-action@68dbd78ba531c95d8ce3d262c9e63291926e9353 # v0.4.0
         with:
           version: 'latest'
-
       - name: Build
         run: trunk build --release
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,10 @@ jobs:
           rustup target add wasm32-unknown-unknown
 
       - name: Install trunk
-        run: |
-          cargo install --locked trunk
+        uses: jetli/trunk-action@v0.4.0
+        with:
+          version: 'latest'
+
       - name: Build
         run: trunk build --release
         env:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -19,9 +19,8 @@ jobs:
           rustup target add wasm32-unknown-unknown
 
       - name: Install trunk
-        uses: jetli/trunk-action@68dbd78ba531c95d8ce3d262c9e63291926e9353 # v0.4.0
-        with:
-          version: 'latest'
+        run: |
+          cargo install --locked trunk
 
       - name: Build
         run: trunk build

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -14,16 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
-          profile: minimal
+      - name: Install wasm target
+        run: |
+          rustup target add wasm32-unknown-unknown
 
       - name: Install trunk
-        uses: jetli/trunk-action@v0.1.0
+        uses: jetli/trunk-action@68dbd78ba531c95d8ce3d262c9e63291926e9353 # v0.4.0
         with:
           version: 'latest'
 

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -14,13 +14,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+
       - name: Install wasm target
         run: |
           rustup target add wasm32-unknown-unknown
 
       - name: Install trunk
-        run: |
-          cargo install --locked trunk
+        uses: jetli/trunk-action@v0.4.0
+        with:
+          version: 'latest'
 
       - name: Build
         run: trunk build


### PR DESCRIPTION
The actions-rs/toolchain action was archived so it's not being maintained anymore, and the trunk-action has a much newer version.

It might be worth seeing if these can be updated in the Yew generator template, which was also referencing v2 of actions/checkout by default.