### PR TITLE
automatically detect the user's default language

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ yew = { git = "https://github.com/yewstack/yew/", features = ["csr"] }
 [dependencies.web-sys]
 version = "0.3"
 features = [
-    "HtmlSelectElement"
+    "HtmlSelectElement",
+    "Navigator"
 ]

--- a/src/components/lang/lang_context.rs
+++ b/src/components/lang/lang_context.rs
@@ -31,7 +31,7 @@ impl Reducible for LangState {
 impl Default for LangState {
     fn default() -> Self {
         LangState {
-            lang: lang::Lang::En,
+            lang: get_navigator_lang().unwrap_or(lang::Lang::En),
         }
     }
 }
@@ -39,6 +39,18 @@ impl Default for LangState {
 #[derive(Properties, PartialEq)]
 pub struct Props {
     pub children: Html,
+}
+
+pub fn get_navigator_lang() -> Option<lang::Lang> {
+    let window = web_sys::window().expect("no global `window` exists");
+
+    match window.navigator().language() {
+        Some(lang) => {
+            // console::debug_1(&lang.clone().into());
+            lang::lang_from_string(lang)
+        }
+        None => None,
+    }
 }
 
 #[function_component]

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,10 +1,16 @@
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum Lang {
-    Jp,
+    De,
     En,
     Es,
     Fr,
-    De,
+    Ja,
+}
+
+impl std::fmt::Display for Lang {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 #[derive(PartialEq, Copy, Clone)]
@@ -20,15 +26,29 @@ mod de;
 mod en_us;
 mod es;
 mod fr;
-mod jp;
+mod ja;
 
 pub fn get_translated_message(lang: Lang, msg: Msg) -> &'static str {
     match lang {
-        Lang::Jp => jp::m(msg),
+        Lang::Ja => ja::m(msg),
         Lang::En => en_us::m(msg),
         Lang::Es => es::m(msg),
         Lang::Fr => fr::m(msg),
         Lang::De => de::m(msg),
+    }
+}
+
+pub fn lang_from_string(lang: String) -> Option<Lang> {
+    let lang = lang.to_lowercase();
+    let lang = &lang[..2];
+
+    match lang {
+        "de" => Some(Lang::De),
+        "en" => Some(Lang::En),
+        "es" => Some(Lang::Es),
+        "fr" => Some(Lang::Fr),
+        "ja" => Some(Lang::Ja),
+        _ => None,
     }
 }
 
@@ -55,6 +75,6 @@ pub fn select_language_options() -> Vec<LangOption> {
         LangOption::new(Lang::En, "en"),
         LangOption::new(Lang::Es, "es"),
         LangOption::new(Lang::Fr, "fr"),
-        LangOption::new(Lang::Jp, "jp"),
+        LangOption::new(Lang::Ja, "jp"),
     ]
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -10,7 +10,7 @@ pub fn m(msg: Msg) -> &'static str {
             super::Lang::En => "Englisch",
             super::Lang::Es => "Spanisch",
             super::Lang::Fr => "Französisch",
-            super::Lang::Jp => "Japanisch",
+            super::Lang::Ja => "Japanisch",
         },
         Msg::ViewCodeLink => "Code auf GitHub anzeigen",
     }

--- a/src/lang/en_us.rs
+++ b/src/lang/en_us.rs
@@ -10,7 +10,7 @@ pub fn m(msg: Msg) -> &'static str {
             super::Lang::En => "English",
             super::Lang::Es => "Spanish",
             super::Lang::Fr => "French",
-            super::Lang::Jp => "Japanese",
+            super::Lang::Ja => "Japanese",
         },
         Msg::ViewCodeLink => "View the code on GitHub",
     }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -10,7 +10,7 @@ pub fn m(msg: Msg) -> &'static str {
             super::Lang::En => "Inglés",
             super::Lang::Es => "Español",
             super::Lang::Fr => "Francés",
-            super::Lang::Jp => "Japonés",
+            super::Lang::Ja => "Japonés",
         },
         Msg::ViewCodeLink => "Ver el código en GitHub",
     }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -10,7 +10,7 @@ pub fn m(msg: Msg) -> &'static str {
             super::Lang::En => "Anglais",
             super::Lang::Es => "Espagnol",
             super::Lang::Fr => "Français",
-            super::Lang::Jp => "Japonais",
+            super::Lang::Ja => "Japonais",
         },
         Msg::ViewCodeLink => "Voir le code sur GitHub",
     }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -10,7 +10,7 @@ pub fn m(msg: Msg) -> &'static str {
             super::Lang::En => "英語",
             super::Lang::Es => "スペイン語",
             super::Lang::Fr => "フランス語",
-            super::Lang::Jp => "日本語",
+            super::Lang::Ja => "日本語",
         },
         Msg::ViewCodeLink => "GitHubでコードを表示",
     }


### PR DESCRIPTION
If the user's primary language for their browser is one of the supported languages, this selects it by default. This could be improved by falling back to checking their list of languages and choosing the first match, since it's possible that their primary language is not one in the list but another in their list is available. Falls back to English.